### PR TITLE
background.js, missing section

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -153,6 +153,14 @@ class BackgroundExtension {
                 funcIndex: null,
                 funcBody: "",
             },
+            stringForm: {
+                strType: "ascii",
+                strMinLen: 4,
+                results: {
+                    count: 0,
+                    object: {},
+                }
+            },
             speedhack: {
                 multiplier: null,
             },


### PR DESCRIPTION
In class "BackgroundExtension" there was a missing section in "reset()" for stringForm. 
This was generating some "undefined" errors for strType