### PR TITLE
add backwards compatibility for older emscripten builds

### DIFF
--- a/content/init.js
+++ b/content/init.js
@@ -811,6 +811,12 @@ const webAssemblyInstantiateStreamingHook = function(sourceObj, importObject) {
     // sections of the binary. But for now this is pretty reliable
     let memoryObj = null;
 
+    // Some older versions of emscripten use importObject.a instead of importObject.env.
+    // Simply link importObject.a to importObject.env if importObject.a exists
+    if (typeof importObject.a !== "undefined" && typeof importObject.env === "undefined") {
+        importObject.env = importObject.a;
+    }
+
     // Emscripten by default stores most of the environment in importObject.env
     // If it doesn't exist already let's create it so we have a place to put 
     // our imported functions


### PR DESCRIPTION
Add a check for importObject.a to link to importObject.env; older emscripten builds have importObject.a instead of importObject.env.
The issue appears when one tries to use memory search on an old emscripten-built app, which will throw a "TypeError: Cannot read property 'buffer' of undefined" error.

An example of this is https://diep.io