### PR TITLE
Correction of patternSearch

### DIFF
--- a/content/cetus.js
+++ b/content/cetus.js
@@ -366,7 +366,7 @@ class Cetus {
 
                 break;
             case "utf-8":
-                const tempBuf = new Uint16Array(searchParams.length);
+                const tempBuf = new Uint16Array(searchParam.length);
 
                 for (let i = 0; i < searchParam.length; i++) {
                     realParam[i] = searchParam.charCodeAt(i);


### PR DESCRIPTION
This will correct the patternSearch, in the submition of the creator he forgot one letter and this break the **utf-8** search.

![brave_Gyfb3TfISg](https://user-images.githubusercontent.com/19374522/187741783-c40a243b-b4da-4f35-887a-fd801cb62a3c.png)

Example URL: https://game317296.konggames.com/gamez/0031/7296/live/index.html